### PR TITLE
Fixed script throwing error when not all KDE games are installed

### DIFF
--- a/game_remover.sh
+++ b/game_remover.sh
@@ -1,4 +1,4 @@
-sudo pacman -Ss kde games > games.txt &&
+sudo pacman -Qs kde games > games.txt &&
 line_count=$(wc -l games.txt | cut -d " " -f1)
 for ((i=1; i<$line_count; i++));do sed -n $((i++))p games.txt >> remove.txt ;done &&
 line_count_two=$(wc -l remove.txt | cut -d " " -f1) 


### PR DESCRIPTION
sudo pacman -Ss fetches every program in the repos that matches the given string, but if a package is not installed the script will throw an error. However, pacman -Qs just fetches the installed games. Just checked and works like a charm.